### PR TITLE
Change how failure reporting is being printed to the screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
-I would like a pytest plugin that will make pytest reports more human-readable
+# EasyPytest
+
+This is a pytest plugin that aims to make the way pytest reports to terminal easier to read.  
+
+To use it add --easy flag when you run the tests, like this:
+```
+pytest --easy
+```

--- a/conftest.py
+++ b/conftest.py
@@ -156,6 +156,13 @@ class RspecifiedTerminalReporter(TerminalReporter):
             line += sepchar.rstrip()
         self._tw.line(line, **kw)
 
+    # inbuilt pytest reporter method; changes made:
+    # change separator for FAILURES heading
+    # add index numbers for titles of failing tests
+    # get rid of dashes separating snippets of code from test file and tested file within failure message for a test;
+    # add an empty line between report printouts for failing tests
+    # format title of failing test and change separator from an equal sign to a dot surrounded by whitespace
+    # and move the title from the centre to the left;
     def summary_failures(self):
         if self.config.option.tbstyle != "no":
             reports = self.getreports('failed')

--- a/conftest.py
+++ b/conftest.py
@@ -132,3 +132,26 @@ class RspecifiedTerminalReporter(TerminalReporter):
             self._tw.write(word, **markup)
             self._tw.write(" " + line)
             self.currentfspath = -2
+
+    # Reporting failures
+    def summary_failures(self):
+        if self.config.option.tbstyle != "no":
+            reports = self.getreports('failed')
+            if not reports:
+                return
+            self.write_sep(".  ", "FAILURES", **{"bold": True})
+            index = 1
+            for rep in reports:
+                if self.config.option.tbstyle == "line":
+                    line = self._getcrashline(rep)
+                    print("HERE?")
+                    self.write_line(line)
+                else:
+                    msg = self._getfailureheadline(rep)
+                    markup = {'red': True, 'bold': True}
+                    self.write_ensure_prefix(str(index) + ". " + msg, **markup)
+                    index += 1
+                    self._outrep_summary(rep)
+                    for report in self.getreports(''):
+                        if report.nodeid == rep.nodeid and report.when == 'teardown':
+                            self.print_teardown_sections(report)

--- a/test_easy_pytest.py
+++ b/test_easy_pytest.py
@@ -3,7 +3,7 @@
 pytest_plugins = "pytester"
 import pytest
 
-class TestRspecifiedTerminalReporter(object):
+class TestEasyTerminalReporter(object):
 
     def setup_method(self, method):
         self.conftest = open("./conftest.py", "r")

--- a/test_easy_pytest.py
+++ b/test_easy_pytest.py
@@ -19,7 +19,7 @@ class TestRspecifiedTerminalReporter(object):
             """
         )
         testdir.makeconftest(self.conftest.read())
-        result = testdir.runpytest('--rspecify')
+        result = testdir.runpytest('--easy')
 
         result.stdout.fnmatch_lines([
             "test_list_of_tests_items_formatted_correctly*",
@@ -38,7 +38,7 @@ class TestRspecifiedTerminalReporter(object):
             """
         testdir.makepyfile(test_list_of_tests=test_content,test_list_of_tests2=test_content)
         testdir.makeconftest(self.conftest.read())
-        result = testdir.runpytest('--rspecify')
+        result = testdir.runpytest('--easy')
 
         expected_result = "\n\ntest_list_of_tests.py \n  failing function (FAILED)\n  passing function (PASSED)\n\ntest_list_of_tests2.py \n  failing function (FAILED)\n  passing function (PASSED)"
         assert expected_result in result.stdout.str()
@@ -58,7 +58,7 @@ class TestRspecifiedTerminalReporter(object):
             """
         testdir.makepyfile(test_list_of_tests=test_content,test_list_of_tests2=test_content)
         testdir.makeconftest(self.conftest.read())
-        result = testdir.runpytest('--rspecify')
+        result = testdir.runpytest('--easy')
 
         expected_result = "test_list_of_tests.py \n  TestClassName \n    failing function (FAILED)\n    passing function (PASSED)\n  TestSecondClass \n    passing function (PASSED)\n\ntest_list_of_tests2.py \n  TestClassName \n    failing function (FAILED)\n    passing function (PASSED)"
         assert expected_result in result.stdout.str()
@@ -78,7 +78,7 @@ class TestRspecifiedTerminalReporter(object):
             """
         testdir.makepyfile(test_list_of_tests=test_content,test_list_of_tests2=test_content)
         testdir.makeconftest(self.conftest.read())
-        result = testdir.runpytest('--rspecify')
+        result = testdir.runpytest('--easy')
 
         assert "1. TestClassName: zero is truthy  .  .  . " and "2. one equals two  .  .  . " in result.stdout.str()
 
@@ -101,7 +101,7 @@ class TestRspecifiedTerminalReporter(object):
             """
         testdir.makepyfile(test_list_of_tests=test_content,test_list_of_tests2=test_content, do_not_panic=do_not_panic)
         testdir.makeconftest(self.conftest.read())
-        result = testdir.runpytest('--rspecify')
+        result = testdir.runpytest('--easy')
         banished_separator = "_ _ _ _"
         assert banished_separator not in result.stdout.str()
 
@@ -116,7 +116,7 @@ class TestRspecifiedTerminalReporter(object):
             """
         testdir.makepyfile(test_list_of_tests=test_content)
         testdir.makeconftest(self.conftest.read())
-        result = testdir.runpytest('--rspecify')
+        result = testdir.runpytest('--easy')
         expected_result = "test_list_of_tests.py:3: AssertionError\n\n\n2. failing function no2"
         assert expected_result in result.stdout.str()
 
@@ -131,7 +131,7 @@ class TestRspecifiedTerminalReporter(object):
             """
         testdir.makepyfile(test_list_of_tests=test_content)
         testdir.makeconftest(self.conftest.read())
-        result = testdir.runpytest('--rspecify')
+        result = testdir.runpytest('--easy')
         expected_result_1 = " \n\n1. failing function"
-        expected_result_2 = " \n\n1. failing function"
+        expected_result_2 = ".\n\n1. failing function"
         assert expected_result_1 or expected_result_2 in result.stdout.str()

--- a/test_rspecify.py
+++ b/test_rspecify.py
@@ -62,3 +62,47 @@ class TestRspecifiedTerminalReporter(object):
 
         expected_result = "test_list_of_tests.py \n  TestClassName \n    failing function (FAILED)\n    passing function (PASSED)\n  TestSecondClass \n    passing function (PASSED)\n\ntest_list_of_tests2.py \n  TestClassName \n    failing function (FAILED)\n    passing function (PASSED)"
         assert expected_result in result.stdout.str()
+
+    def test_failure_titles_have_index_numbers_and_formatting(self, testdir):
+        test_content = """
+            import pytest
+            class TestClassName(object):
+                def test_zero_is_truthy(self):
+                    assert 0
+
+                def test_passing_function(self):
+                    assert 1 == 1
+
+            def test_one_equals_two():
+                assert 1 == 2
+            """
+        testdir.makepyfile(test_list_of_tests=test_content,test_list_of_tests2=test_content)
+        testdir.makeconftest(self.conftest.read())
+        result = testdir.runpytest('--rspecify')
+
+        result.stdout.fnmatch_lines([
+            "1. TestClassName: zero is truthy",
+            "2. one equals two",
+        ])
+
+    def test_there_are_no_separator_dashes_within_report_messages(self, testdir):
+        test_content = """
+            import pytest
+            from do_not_panic import is_it_answer_to_life_universe_and_everything
+            class TestClassName(object):
+                def test_is_it_answer_to_life_universe_and_everything_throws_error_if_string_passed_in(self):
+                    assert is_it_answer_to_life_universe_and_everything("love") == True
+            """
+
+        do_not_panic = """
+            def is_it_answer_to_life_universe_and_everything(integer):
+                if isinstance(integer, int):
+                    return integer == 42
+                else:
+                    raise NameError("Hint: it's a number! :P")
+            """
+        testdir.makepyfile(test_list_of_tests=test_content,test_list_of_tests2=test_content, do_not_panic=do_not_panic)
+        testdir.makeconftest(self.conftest.read())
+        result = testdir.runpytest('--rspecify')
+        banished_separator = "_ _ _ _"
+        assert banished_separator not in result.stdout.str()

--- a/test_rspecify.py
+++ b/test_rspecify.py
@@ -80,10 +80,8 @@ class TestRspecifiedTerminalReporter(object):
         testdir.makeconftest(self.conftest.read())
         result = testdir.runpytest('--rspecify')
 
-        result.stdout.fnmatch_lines([
-            "1. TestClassName: zero is truthy",
-            "2. one equals two",
-        ])
+        assert "1. TestClassName: zero is truthy  .  .  . " and "2. one equals two  .  .  . " in result.stdout.str()
+
 
     def test_there_are_no_separator_dashes_within_report_messages(self, testdir):
         test_content = """
@@ -106,3 +104,34 @@ class TestRspecifiedTerminalReporter(object):
         result = testdir.runpytest('--rspecify')
         banished_separator = "_ _ _ _"
         assert banished_separator not in result.stdout.str()
+
+    def test_there_are_two_empty_lines_before_second_failure(self, testdir):
+        test_content = """
+            import pytest
+            def test_failing_function():
+                assert 0
+
+            def test_failing_function_no2():
+                assert 1 != 1
+            """
+        testdir.makepyfile(test_list_of_tests=test_content)
+        testdir.makeconftest(self.conftest.read())
+        result = testdir.runpytest('--rspecify')
+        expected_result = "test_list_of_tests.py:3: AssertionError\n\n\n2. failing function no2"
+        assert expected_result in result.stdout.str()
+
+    def test_there_is_one_empty_line_before_first_failure(self, testdir):
+        test_content = """
+            import pytest
+            def test_failing_function():
+                assert 0
+
+            def test_failing_function_no2():
+                assert 1 != 1
+            """
+        testdir.makepyfile(test_list_of_tests=test_content)
+        testdir.makeconftest(self.conftest.read())
+        result = testdir.runpytest('--rspecify')
+        expected_result_1 = " \n\n1. failing function"
+        expected_result_2 = " \n\n1. failing function"
+        assert expected_result_1 or expected_result_2 in result.stdout.str()


### PR DESCRIPTION
- change how the “FAILURES” header is presented, mainly change separator from an equal sign to a dot surrounded by whitespace;
- add indexing for each failure;
- format title of failing test and change separator from an equal sign to a dot surrounded by whitespace and move the title from the centre to the left;
- get rid of dashes separating snippets of code from test file and tested file within failure message for a test;
- add an empty line between report printouts for failing tests
- make methods called only from within the class private
- refactor code for SRP and inefficiencies
- change name from rspecify_pytest to EasyPytest
